### PR TITLE
Remove Deprecation Warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ function WebpackTouch(options) {
 }
 
 WebpackTouch.prototype.write = function() {
-  fs.writeFile(this.filename, 'DONE', {flag: 'w+'});
+  fs.writeFile(this.filename, 'DONE', {flag: 'w+'}, function(err) {
+    if (err) {
+      console.error(err)
+    }
+  });
 }
 
 WebpackTouch.prototype.apply = function(compiler) {


### PR DESCRIPTION
As of node version 7.10 (at least), using `writeFile` without a callback is deprecated, and prints a warning to the console:
```
(node:21075) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```
This change also prints any fs error to the console too, which might be useful for users anwyay.